### PR TITLE
Space Insulation upgrade/enchantment

### DIFF
--- a/src/main/java/boss_tools_giselle_addon/common/compat/mekanism/AddonMekanismCommonEventListener.java
+++ b/src/main/java/boss_tools_giselle_addon/common/compat/mekanism/AddonMekanismCommonEventListener.java
@@ -45,13 +45,13 @@ public class AddonMekanismCommonEventListener
 	@SubscribeEvent
 	public static void onLivingSetFireInHotPlanet(LivingSetFireInHotPlanetEvent e)
 	{
-		AddonModuleHelper.tryCancel(e, AddonMekanismModules.SPACE_FIRE_PROOF_UNIT, ModuleSpaceFireProofUnit::getEnergyUsing);
+		AddonModuleHelper.tryCancel(e, AddonMekanismModules.SPACE_FIRE_PROOF_UNIT, ModuleSpaceFireProofUnit::getEnergyUsing, true);
 	}
 
 	@SubscribeEvent
 	public static void onLivingSetVenusRain(LivingSetVenusRainEvent e)
 	{
-		AddonModuleHelper.tryCancel(e, AddonMekanismModules.VENUS_ACID_PROOF_UNIT, ModuleVenusAcidProofUnit::getEnergyUsing);
+		AddonModuleHelper.tryCancel(e, AddonMekanismModules.VENUS_ACID_PROOF_UNIT, ModuleVenusAcidProofUnit::getEnergyUsing, true);
 	}
 
 	private AddonMekanismCommonEventListener()

--- a/src/main/java/boss_tools_giselle_addon/common/compat/mekanism/AddonModuleHelper.java
+++ b/src/main/java/boss_tools_giselle_addon/common/compat/mekanism/AddonModuleHelper.java
@@ -4,15 +4,19 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
+import boss_tools_giselle_addon.common.config.AddonConfigs;
 import mekanism.api.gear.ICustomModule;
 import mekanism.api.math.FloatingLong;
 import mekanism.api.providers.IModuleDataProvider;
 import mekanism.common.content.gear.Module;
 import mekanism.common.content.gear.ModuleHelper;
+import mekanism.common.item.gear.ItemMekaSuitArmor;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.inventory.EquipmentSlotType.Group;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.living.LivingEvent;
 
@@ -34,6 +38,31 @@ public class AddonModuleHelper
 		return null;
 	}
 
+	public static boolean testFullParts(LivingEntity living)
+	{
+		if (!AddonConfigs.Common.mekanism.modulesWorkFullParts.get())
+		{
+			return true;
+		}
+
+		for (EquipmentSlotType slot : EquipmentSlotType.values())
+		{
+			if (slot.getType() == Group.ARMOR)
+			{
+				ItemStack stack = living.getItemBySlot(slot);
+
+				if (!(stack.getItem() instanceof ItemMekaSuitArmor))
+				{
+					return false;
+				}
+
+			}
+
+		}
+
+		return true;
+	}
+
 	/**
 	 *
 	 * @param <T>
@@ -47,6 +76,23 @@ public class AddonModuleHelper
 	 * @return Whether canceled in this method
 	 */
 	public static <T extends ICustomModule<T>> boolean tryCancel(LivingEvent e, IModuleDataProvider<T> type, @Nullable Function<T, FloatingLong> getEnergyUsing)
+	{
+		return tryCancel(e, type, getEnergyUsing, false);
+	}
+
+	/**
+	 *
+	 * @param <T>
+	 *            T extends mekanism.common.content.gear.Module
+	 * @param e
+	 *            Cancelable LivingEvent
+	 * @param type
+	 *            Module Type
+	 * @param getEnergyUsing
+	 *            Energy function for cancel
+	 * @return Whether canceled in this method
+	 */
+	public static <T extends ICustomModule<T>> boolean tryCancel(LivingEvent e, IModuleDataProvider<T> type, @Nullable Function<T, FloatingLong> getEnergyUsing, boolean testFullParts)
 	{
 		if (e.isCancelable() == false || e.isCanceled() == true)
 		{
@@ -63,6 +109,10 @@ public class AddonModuleHelper
 			if (entity instanceof PlayerEntity && MekanismUtils.isPlayingMode((PlayerEntity) entity) == false)
 			{
 				cancel = true;
+			}
+			else if (testFullParts && !testFullParts(entity))
+			{
+				cancel = false;
 			}
 			else if (getEnergyUsing != null)
 			{

--- a/src/main/java/boss_tools_giselle_addon/common/compat/mekanism/gear/ModuleSpaceBreathingUnit.java
+++ b/src/main/java/boss_tools_giselle_addon/common/compat/mekanism/gear/ModuleSpaceBreathingUnit.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import boss_tools_giselle_addon.common.BossToolsAddon;
 import boss_tools_giselle_addon.common.capability.IOxygenCharger;
 import boss_tools_giselle_addon.common.capability.OxygenChargerUtils;
+import boss_tools_giselle_addon.common.compat.mekanism.AddonModuleHelper;
 import boss_tools_giselle_addon.common.config.AddonConfigs;
 import mekanism.api.Action;
 import mekanism.api.MekanismAPI;
@@ -138,6 +139,15 @@ public class ModuleSpaceBreathingUnit implements ICustomModule<ModuleSpaceBreath
 
 	public boolean useResources(IModule<ModuleSpaceBreathingUnit> module, LivingEntity entity)
 	{
+		if (entity instanceof PlayerEntity && MekanismUtils.isPlayingMode((PlayerEntity) entity) == false)
+		{
+			return true;
+		}
+		else if (!AddonModuleHelper.testFullParts(entity))
+		{
+			return false;
+		}
+
 		int oyxgenUsing = 1;
 		IOxygenCharger oxygenCharnger = OxygenChargerUtils.firstExtractableOxygenCharger(entity, oyxgenUsing, module.getContainer());
 

--- a/src/main/java/boss_tools_giselle_addon/common/compat/pneumaticcraft/AddonPneumaticCraftEventHandler.java
+++ b/src/main/java/boss_tools_giselle_addon/common/compat/pneumaticcraft/AddonPneumaticCraftEventHandler.java
@@ -14,6 +14,8 @@ import me.desht.pneumaticcraft.common.item.ItemPneumaticArmor;
 import me.desht.pneumaticcraft.common.pneumatic_armor.CommonArmorHandler;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.inventory.EquipmentSlotType.Group;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -23,6 +25,31 @@ import net.mrscauthd.boss_tools.events.forgeevents.LivingSetVenusRainEvent;
 
 public class AddonPneumaticCraftEventHandler
 {
+	public static boolean testFullParts(LivingEntity living)
+	{
+		if (!AddonConfigs.Common.pneumaticcraft.upgradesWorkFullParts.get())
+		{
+			return true;
+		}
+
+		for (EquipmentSlotType slot : EquipmentSlotType.values())
+		{
+			if (slot.getType() == Group.ARMOR)
+			{
+				ItemStack stack = living.getItemBySlot(slot);
+
+				if (!(stack.getItem() instanceof ItemPneumaticArmor))
+				{
+					return false;
+				}
+
+			}
+
+		}
+
+		return true;
+	}
+
 	@SubscribeEvent
 	public static void onLivingSpaceOxygenProofEvent(LivingSpaceOxygenProofEvent e)
 	{
@@ -36,7 +63,7 @@ public class AddonPneumaticCraftEventHandler
 		PlayerEntity player = (PlayerEntity) entity;
 		ItemStack stack = getUpgradeUsablePneumaticArmorItem(player, AddonCommonUpgradeHandlers.SPACE_BREATHING);
 
-		if (stack.isEmpty() == true)
+		if (stack.isEmpty() == true || !testFullParts(player))
 		{
 			return;
 		}
@@ -73,16 +100,21 @@ public class AddonPneumaticCraftEventHandler
 	@SubscribeEvent
 	public static void onLivingSetFireInHotPlanet(LivingSetFireInHotPlanetEvent e)
 	{
-		tryCancel(e, AddonCommonUpgradeHandlers.SPACE_FIRE_PROOF, AddonConfigs.Common.pneumaticcraft.upgrade_space_fire_proof_airUsing.get());
+		tryCancel(e, AddonCommonUpgradeHandlers.SPACE_FIRE_PROOF, AddonConfigs.Common.pneumaticcraft.upgrade_space_fire_proof_airUsing.get(), true);
 	}
 
 	@SubscribeEvent
 	public static void onLivingSetVenusRain(LivingSetVenusRainEvent e)
 	{
-		tryCancel(e, AddonCommonUpgradeHandlers.VENUS_ACID_PROOF, AddonConfigs.Common.pneumaticcraft.upgrade_venus_acid_proof_airUsing.get());
+		tryCancel(e, AddonCommonUpgradeHandlers.VENUS_ACID_PROOF, AddonConfigs.Common.pneumaticcraft.upgrade_venus_acid_proof_airUsing.get(), true);
 	}
 
 	public static boolean tryCancel(EntityEvent e, IArmorUpgradeHandler<?> upgradeHandler, int airUsing)
+	{
+		return tryCancel(e, upgradeHandler, airUsing, false);
+	}
+
+	public static boolean tryCancel(EntityEvent e, IArmorUpgradeHandler<?> upgradeHandler, int airUsing, boolean testFullParts)
 	{
 		if (e.isCancelable() == false || e.isCanceled() == true || !(e.getEntity() instanceof PlayerEntity))
 		{
@@ -92,7 +124,7 @@ public class AddonPneumaticCraftEventHandler
 		PlayerEntity player = (PlayerEntity) e.getEntity();
 		ItemStack stack = getUpgradeUsablePneumaticArmorItem(player, upgradeHandler);
 
-		if (stack.isEmpty() == true)
+		if (stack.isEmpty() == true || (testFullParts && !testFullParts(player)))
 		{
 			return false;
 		}

--- a/src/main/java/boss_tools_giselle_addon/common/config/EnchantmentsConfig.java
+++ b/src/main/java/boss_tools_giselle_addon/common/config/EnchantmentsConfig.java
@@ -7,8 +7,6 @@ public class EnchantmentsConfig
 {
 	public final ConfigValue<Boolean> tooltip_Enabled;
 	public final ConfigValue<Boolean> tooltip_Ignore;
-	public final ConfigValue<Boolean> enchant_least_iron;
-	public final ConfigValue<Boolean> work_full_parts_least_iron;
 
 	public final ConfigValue<Boolean> enchant_least_iron;
 	public final ConfigValue<Boolean> work_full_parts_least_iron;
@@ -47,9 +45,6 @@ public class EnchantmentsConfig
 				"But, if this set 'true' show tooltip with ignore that mods");
 		this.tooltip_Ignore = builder.define("ignore", false);
 		builder.comment("The item to enchant should be have defence points equals or greater than Iron Armors");
-		this.enchant_least_iron = builder.define("enchant_least_iron", false);
-		builder.comment("The enchantment to work, Player should be need equip all parts of armor that defence points least Iron Armors");
-		this.work_full_parts_least_iron = builder.define("work_full_parts_least_iron", false);
 
 		builder.pop();
 

--- a/src/main/java/boss_tools_giselle_addon/common/config/EnchantmentsConfig.java
+++ b/src/main/java/boss_tools_giselle_addon/common/config/EnchantmentsConfig.java
@@ -7,6 +7,8 @@ public class EnchantmentsConfig
 {
 	public final ConfigValue<Boolean> tooltip_Enabled;
 	public final ConfigValue<Boolean> tooltip_Ignore;
+	public final ConfigValue<Boolean> enchant_least_iron;
+	public final ConfigValue<Boolean> work_full_parts_least_iron;
 
 	public final ConfigValue<Integer> space_breathing_energy_using;
 	public final ConfigValue<Integer> space_breathing_energy_duration;
@@ -36,11 +38,15 @@ public class EnchantmentsConfig
 
 		builder.push("tooltip");
 
-		builder.comment("show tooltip on THIS mod's enchanted book");
+		builder.comment("Show tooltip on THIS mod's enchanted book");
 		this.tooltip_Enabled = builder.define("enabled", true);
-		builder.comment("tooltip will don't show when 'Enchantment Descriptions' or 'CoFH Core' installed", //
-				"but, if this set 'true' show tooltip with ignore that mods");
+		builder.comment("Tooltip will don't show when 'Enchantment Descriptions' or 'CoFH Core' installed", //
+				"But, if this set 'true' show tooltip with ignore that mods");
 		this.tooltip_Ignore = builder.define("ignore", false);
+		builder.comment("The item to enchant should be have defence points equals or greater than Iron Armors");
+		this.enchant_least_iron = builder.define("enchant_least_iron", false);
+		builder.comment("The enchantment to work, Player should be need equip all parts of armor that defence points least Iron Armors");
+		this.work_full_parts_least_iron = builder.define("work_full_parts_least_iron", false);
 
 		builder.pop();
 

--- a/src/main/java/boss_tools_giselle_addon/common/config/EnchantmentsConfig.java
+++ b/src/main/java/boss_tools_giselle_addon/common/config/EnchantmentsConfig.java
@@ -8,6 +8,9 @@ public class EnchantmentsConfig
 	public final ConfigValue<Boolean> tooltip_Enabled;
 	public final ConfigValue<Boolean> tooltip_Ignore;
 
+	public final ConfigValue<Boolean> enchant_least_iron;
+	public final ConfigValue<Boolean> work_full_parts_least_iron;
+
 	public final ConfigValue<Integer> space_breathing_energy_using;
 	public final ConfigValue<Integer> space_breathing_energy_duration;
 	public final ConfigValue<Integer> space_breathing_energy_oxygen;
@@ -36,13 +39,18 @@ public class EnchantmentsConfig
 
 		builder.push("tooltip");
 
-		builder.comment("show tooltip on THIS mod's enchanted book");
+		builder.comment("Show tooltip on THIS mod's enchanted book");
 		this.tooltip_Enabled = builder.define("enabled", true);
-		builder.comment("tooltip will don't show when 'Enchantment Descriptions' or 'CoFH Core' installed", //
-				"but, if this set 'true' show tooltip with ignore that mods");
+		builder.comment("Tooltip will don't show when 'Enchantment Descriptions' or 'CoFH Core' installed", //
+				"But, if this set 'true' show tooltip with ignore that mods");
 		this.tooltip_Ignore = builder.define("ignore", false);
 
 		builder.pop();
+
+		builder.comment("The item to enchant should be have defence points equals or greater than Iron Armors");
+		this.enchant_least_iron = builder.define("enchant_least_iron", false);
+		builder.comment("The enchantment to work, Player should be need equip all parts of armor that defence points least Iron Armors");
+		this.work_full_parts_least_iron = builder.define("work_full_parts_least_iron", false);
 
 		builder.pop();
 

--- a/src/main/java/boss_tools_giselle_addon/common/config/MekanismConfig.java
+++ b/src/main/java/boss_tools_giselle_addon/common/config/MekanismConfig.java
@@ -5,6 +5,8 @@ import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 
 public class MekanismConfig
 {
+	public final ConfigValue<Boolean> modulesWorkFullParts;
+	
 	public final ConfigValue<Integer> moduleSpaceBreathing_oxygenDuration;
 	public final ConfigValue<Integer> moduleSpaceBreathing_energyUsingProvide;
 	public final ConfigValue<Integer> moduleSpaceBreathing_energyUsingProduce;
@@ -18,6 +20,9 @@ public class MekanismConfig
 
 	public MekanismConfig(ForgeConfigSpec.Builder builder)
 	{
+		builder.comment("Modules to work, Player should be need equip all parts of Meka-Suit");
+		this.modulesWorkFullParts = builder.define("modules_work_full_parts", false);
+		
 		builder.push("module_space_breathing_unit");
 		builder.comment("Duration of provided oxygen (oxygen provide interval)");
 		this.moduleSpaceBreathing_oxygenDuration = builder.define("oxygenDuration", 4);

--- a/src/main/java/boss_tools_giselle_addon/common/config/PneumaticCraftConfig.java
+++ b/src/main/java/boss_tools_giselle_addon/common/config/PneumaticCraftConfig.java
@@ -5,6 +5,8 @@ import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 
 public class PneumaticCraftConfig
 {
+	public final ConfigValue<Boolean> upgradesWorkFullParts;
+	
 	public final ConfigValue<Integer> upgrade_space_breating_oxygenDuration;
 	public final ConfigValue<Integer> upgrade_space_breating_airUsing;
 
@@ -14,6 +16,9 @@ public class PneumaticCraftConfig
 
 	public PneumaticCraftConfig(ForgeConfigSpec.Builder builder)
 	{
+		builder.comment("Upgrades to work, Player should be need equip all parts of Pneumatic-Armor");
+		this.upgradesWorkFullParts = builder.define("upgrades_work_full_parts", false);
+		
 		builder.push("space_breating_upgrade");
 		builder.comment("Duration of provided oxygen (oxygen provide interval)");
 		this.upgrade_space_breating_oxygenDuration = builder.define("oxygenDuration", 4);

--- a/src/main/java/boss_tools_giselle_addon/common/content/proof/ProofEnchantmentSession.java
+++ b/src/main/java/boss_tools_giselle_addon/common/content/proof/ProofEnchantmentSession.java
@@ -47,22 +47,29 @@ public abstract class ProofEnchantmentSession extends ProofSession
 			return false;
 		}
 
-		if (LivingEntityHelper.isPlayingMode(this.getEntity()) == true)
-		{
-			if (ItemStackUtils.hasUseableResources(enchantedItem) == true)
-			{
-				int energyUsing = this.getResourceUsingAmount(ItemUsableResource.Energy);
-				int durabilityUsing = this.getResourceUsingAmount(ItemUsableResource.Durability);
-				ItemUsableResourceResult result = ItemStackUtils.useResources(enchantedItem, energyUsing, durabilityUsing, true);
-				this.testedUsableResource = result.getResource();
+		LivingEntity living = this.getEntity();
 
-				if (result.getResult() == false)
+		if (LivingEntityHelper.isPlayingMode(living) == true)
+		{
+			if (EnchantmentEnergyStorageOrDamageable.testWorkLeastIron(living) == true)
+			{
+				if (ItemStackUtils.hasUseableResources(enchantedItem) == true)
 				{
-					return false;
+					int energyUsing = this.getResourceUsingAmount(ItemUsableResource.Energy);
+					int durabilityUsing = this.getResourceUsingAmount(ItemUsableResource.Durability);
+					ItemUsableResourceResult result = ItemStackUtils.useResources(enchantedItem, energyUsing, durabilityUsing, true);
+					this.testedUsableResource = result.getResource();
+
+					if (result.getResult() == true)
+					{
+						return true;
+					}
+
 				}
 
 			}
 
+			return false;
 		}
 		else
 		{

--- a/src/main/java/boss_tools_giselle_addon/common/enchantment/EnchantmentEnergyStorageOrDamageable.java
+++ b/src/main/java/boss_tools_giselle_addon/common/enchantment/EnchantmentEnergyStorageOrDamageable.java
@@ -1,13 +1,26 @@
 package boss_tools_giselle_addon.common.enchantment;
 
+import boss_tools_giselle_addon.common.config.AddonConfigs;
+import boss_tools_giselle_addon.common.util.ArmorUtils;
 import boss_tools_giselle_addon.common.util.ItemStackUtils;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentType;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 
 public class EnchantmentEnergyStorageOrDamageable extends Enchantment
 {
+	public static boolean testEnchantLeastIron(ItemStack stack)
+	{
+		return !AddonConfigs.Common.enchantments.enchant_least_iron.get() || ArmorUtils.isLeastIron(stack);
+	}
+
+	public static boolean testWorkLeastIron(LivingEntity living)
+	{
+		return !AddonConfigs.Common.enchantments.work_full_parts_least_iron.get() || ArmorUtils.allEquipLeastIron(living);
+	}
+
 	public EnchantmentEnergyStorageOrDamageable(Rarity rarity, EnchantmentType type, EquipmentSlotType... slots)
 	{
 		super(rarity, type, slots);
@@ -28,7 +41,7 @@ public class EnchantmentEnergyStorageOrDamageable extends Enchantment
 		}
 		else
 		{
-			return ItemStackUtils.hasUseableResources(stack);
+			return ItemStackUtils.hasUseableResources(stack) && testEnchantLeastIron(stack);
 		}
 
 	}

--- a/src/main/java/boss_tools_giselle_addon/common/util/ArmorUtils.java
+++ b/src/main/java/boss_tools_giselle_addon/common/util/ArmorUtils.java
@@ -1,0 +1,62 @@
+package boss_tools_giselle_addon.common.util;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.inventory.EquipmentSlotType.Group;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.ArmorMaterial;
+import net.minecraft.item.IArmorMaterial;
+import net.minecraft.item.ItemStack;
+
+public class ArmorUtils
+{
+	public static boolean allEquipLeastIron(LivingEntity living)
+	{
+		for (EquipmentSlotType slot : EquipmentSlotType.values())
+		{
+			if (slot.getType() == Group.ARMOR)
+			{
+				ItemStack stack = living.getItemBySlot(slot);
+
+				if (isLeastIron(stack) == false)
+				{
+					return false;
+				}
+
+			}
+
+		}
+
+		return true;
+	}
+
+	public static boolean isLeastIron(ItemStack stack)
+	{
+		return getPrimaryDefence(stack) >= getPrimaryDefence(ArmorMaterial.IRON);
+	}
+
+	public static int getPrimaryDefence(ItemStack stack)
+	{
+		if (stack.getItem() instanceof ArmorItem)
+		{
+			ArmorItem armorItem = (ArmorItem) stack.getItem();
+			return getPrimaryDefence(armorItem.getMaterial());
+		}
+		else
+		{
+			return 0;
+		}
+
+	}
+
+	public static int getPrimaryDefence(IArmorMaterial material)
+	{
+		return material.getDefenseForSlot(EquipmentSlotType.CHEST);
+	}
+
+	private ArmorUtils()
+	{
+
+	}
+
+}


### PR DESCRIPTION
For #135 
Below things are configurable, default is false.
1. Space Breathing, Space Fire Proof, Venus Acid Proof Enchantments are require player equip armors of all parts that item have defense points least Iron Armors.
2. Meka-Suit Modules are require equip all parts of Meka-Suit.
3. PNC Upgrades are require equip all parts of Pneumatic-Armor.